### PR TITLE
SB-4918: Make user_name, password, and organization_eid dynamic

### DIFF
--- a/lib/adroll.rb
+++ b/lib/adroll.rb
@@ -26,15 +26,15 @@ module AdRoll
     end
 
     def self.user_name
-      @user_name
+      @user_name || ENV['ADROLL_USERNAME']
     end
 
     def self.password
-      @password
+      @password || ENV['ADROLL_PASSWORD']
     end
 
     def self.organization_eid
-      @organization_eid
+      @organization_eid || ENV['ADROLL_ORGANIZATION_EID']
     end
 
     def self.set_account_data(user_name, password, organization_eid)

--- a/lib/adroll.rb
+++ b/lib/adroll.rb
@@ -21,20 +21,16 @@ require 'adroll/user'
 
 module AdRoll
   module Api
-    def self.user_name
-      ENV['ADROLL_USERNAME']
-    end
+    def self.included(base)
+      base.class_eval do
+        class << self
+          attr_accessor :user_name, :password, :organization_eid
 
-    def self.password
-      ENV['ADROLL_PASSWORD']
-    end
-
-    def self.organization_eid
-      ENV['ADROLL_ORGANIZATION_EID']
-    end
-
-    def self.base_url
-      'https://api.adroll.com/v1'
+          def base_url
+            'https://api.adroll.com/v1'
+          end
+        end
+      end
     end
   end
 end

--- a/lib/adroll.rb
+++ b/lib/adroll.rb
@@ -21,14 +21,36 @@ require 'adroll/user'
 
 module AdRoll
   module Api
+      def self.base_url
+        'https://api.adroll.com/v1'
+      end
+
+      def self.user_name
+        @user_name
+      end
+
+      def self.password
+        @password
+      end
+
+      def self.organization_eid
+        @organization_eid
+      end
+
+      def self.set_account_data(user_name, password, organization_eid)
+        @user_name = user_name
+        @password = password
+        @organization_eid = organization_eid
+      end
+
     def self.included(base)
       base.class_eval do
         class << self
-          attr_accessor :user_name, :password, :organization_eid
 
-          def base_url
-            'https://api.adroll.com/v1'
+          def set_account_data(user_name: , password: , organization_eid: )
+            AdRoll::Api.set_account_data(user_name, password, organization_eid)
           end
+
         end
       end
     end

--- a/lib/adroll.rb
+++ b/lib/adroll.rb
@@ -21,27 +21,27 @@ require 'adroll/user'
 
 module AdRoll
   module Api
-      def self.base_url
-        'https://api.adroll.com/v1'
-      end
+    def self.base_url
+      'https://api.adroll.com/v1'
+    end
 
-      def self.user_name
-        @user_name
-      end
+    def self.user_name
+      @user_name
+    end
 
-      def self.password
-        @password
-      end
+    def self.password
+      @password
+    end
 
-      def self.organization_eid
-        @organization_eid
-      end
+    def self.organization_eid
+      @organization_eid
+    end
 
-      def self.set_account_data(user_name, password, organization_eid)
-        @user_name = user_name
-        @password = password
-        @organization_eid = organization_eid
-      end
+    def self.set_account_data(user_name, password, organization_eid)
+      @user_name = user_name
+      @password = password
+      @organization_eid = organization_eid
+    end
 
     def self.included(base)
       base.class_eval do

--- a/lib/adroller/version.rb
+++ b/lib/adroller/version.rb
@@ -1,3 +1,3 @@
 module Adroller
-  VERSION = '2.0.0'
+  VERSION = '1.3.0'
 end

--- a/lib/adroller/version.rb
+++ b/lib/adroller/version.rb
@@ -1,3 +1,3 @@
 module Adroller
-  VERSION = '1.2.3'
+  VERSION = '2.0.0'
 end

--- a/lib/adroller/version.rb
+++ b/lib/adroller/version.rb
@@ -1,3 +1,3 @@
 module Adroller
-  VERSION = '1.2.2'
+  VERSION = '1.2.3'
 end

--- a/spec/lib/adroll_spec.rb
+++ b/spec/lib/adroll_spec.rb
@@ -7,24 +7,21 @@ end
 describe AdRoll::Api do
   subject { Dummy }
 
-  describe 'when included' do
-    it 'should define user_name with attr_accessor' do
-      expect(subject.respond_to?(:user_name)).to be_truthy
-      expect(subject.respond_to?(:user_name=)).to be_truthy
+  describe '#set_account_data' do
+    before do
+      subject.set_account_data(user_name: 'username', password: 'abc', organization_eid: 'abc123')
     end
 
-    it 'should define password with attr_accessor' do
-      expect(subject.respond_to?(:password)).to be_truthy
-      expect(subject.respond_to?(:password=)).to be_truthy
+    it 'sets user_name' do
+      expect(AdRoll::Api.user_name).to eq('username')
     end
 
-    it 'should define organization_eid with attr_accessor' do
-      expect(subject.respond_to?(:organization_eid)).to be_truthy
-      expect(subject.respond_to?(:organization_eid=)).to be_truthy
+    it 'sets password' do
+      expect(AdRoll::Api.password).to eq('abc')
     end
 
-    it 'should define self.base_url' do
-      expect(subject.base_url).to eq 'https://api.adroll.com/v1'
+    it 'sets organization_eid' do
+      expect(AdRoll::Api.organization_eid).to eq('abc123')
     end
   end
 end

--- a/spec/lib/adroll_spec.rb
+++ b/spec/lib/adroll_spec.rb
@@ -1,13 +1,29 @@
 require 'spec_helper'
 
-class Dummy
-  include AdRoll::Api
-end
-
 describe AdRoll::Api do
-  subject { Dummy }
 
-  describe '#set_account_data' do
+  context 'when using enviroment variables' do
+
+    it 'sets user_name' do
+      expect(AdRoll::Api.user_name).to eq('USERNAME')
+    end
+
+    it 'sets password' do
+      expect(AdRoll::Api.password).to eq('PASSWORD')
+    end
+
+    it 'sets organization_eid' do
+      expect(AdRoll::Api.organization_eid).to eq('ORG123XYZ')
+    end
+  end
+
+  context 'when using include' do
+    class Dummy
+      include AdRoll::Api
+    end
+
+    subject { Dummy }
+
     before do
       subject.set_account_data(user_name: 'username', password: 'abc', organization_eid: 'abc123')
     end

--- a/spec/lib/adroll_spec.rb
+++ b/spec/lib/adroll_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
+class Dummy
+  include AdRoll::Api
+end
+
 describe AdRoll::Api do
-  subject { described_class }
+  subject { Dummy }
 
   it 'should return username' do
     expect(subject.user_name).to eq 'USERNAME'

--- a/spec/lib/adroll_spec.rb
+++ b/spec/lib/adroll_spec.rb
@@ -4,23 +4,27 @@ class Dummy
   include AdRoll::Api
 end
 
-describe AdRoll::Api do
+fdescribe AdRoll::Api do
   subject { Dummy }
 
-  it 'should return username' do
-    expect(subject.user_name).to eq 'USERNAME'
-  end
+  describe 'when included' do
+    it 'should define user_name with attr_accessor' do
+      expect(subject.respond_to?(:user_name)).to be_truthy
+      expect(subject.respond_to?(:user_name=)).to be_truthy
+    end
 
-  it 'should return password' do
-    expect(subject.password).to eq 'PASSWORD'
-  end
+    it 'should define user_name with attr_accessor' do
+      expect(subject.respond_to?(:password)).to be_truthy
+      expect(subject.respond_to?(:password=)).to be_truthy
+    end
 
-  it 'should return organization eid' do
-    expect(subject.organization_eid).to eq 'ORG123XYZ'
-  end
+    it 'should define user_name with attr_accessor' do
+      expect(subject.respond_to?(:organization_eid)).to be_truthy
+      expect(subject.respond_to?(:organization_eid=)).to be_truthy
+    end
 
-  it 'should return the base url for api endpoints' do
-    expect(subject.base_url).to eq 'https://api.adroll.com/v1'
+    it 'should define self.base_url' do
+      expect(subject.base_url).to eq 'https://api.adroll.com/v1'
+    end
   end
-
 end

--- a/spec/lib/adroll_spec.rb
+++ b/spec/lib/adroll_spec.rb
@@ -4,7 +4,7 @@ class Dummy
   include AdRoll::Api
 end
 
-fdescribe AdRoll::Api do
+describe AdRoll::Api do
   subject { Dummy }
 
   describe 'when included' do
@@ -13,12 +13,12 @@ fdescribe AdRoll::Api do
       expect(subject.respond_to?(:user_name=)).to be_truthy
     end
 
-    it 'should define user_name with attr_accessor' do
+    it 'should define password with attr_accessor' do
       expect(subject.respond_to?(:password)).to be_truthy
       expect(subject.respond_to?(:password=)).to be_truthy
     end
 
-    it 'should define user_name with attr_accessor' do
+    it 'should define organization_eid with attr_accessor' do
       expect(subject.respond_to?(:organization_eid)).to be_truthy
       expect(subject.respond_to?(:organization_eid=)).to be_truthy
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,12 +9,10 @@ RSpec.configure do |config|
   config.before(:each) do
     stub_request(:any, /https:\/\/USERNAME:PASSWORD@api.adroll.com\/v1\//)
       .to_return(status: [200, 'OK'], body: { results: {} }.to_json)
+
+    AdRoll::Api.set_account_data('USERNAME', 'PASSWORD', 'ORG123XYZ')
   end
 end
 
 FactoryGirl.definition_file_paths = [File.expand_path('../factories', __FILE__)]
 FactoryGirl.find_definitions
-
-ENV['ADROLL_USERNAME'] = 'USERNAME'
-ENV['ADROLL_PASSWORD'] = 'PASSWORD'
-ENV['ADROLL_ORGANIZATION_EID'] = 'ORG123XYZ'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,3 +16,7 @@ end
 
 FactoryGirl.definition_file_paths = [File.expand_path('../factories', __FILE__)]
 FactoryGirl.find_definitions
+
+ENV['ADROLL_USERNAME'] = 'USERNAME'
+ENV['ADROLL_PASSWORD'] = 'PASSWORD'
+ENV['ADROLL_ORGANIZATION_EID'] = 'ORG123XYZ'


### PR DESCRIPTION
### Problem
Current version of the gem uses ENV variables for user_name, password, and organization_eid.

### Solution
Use some fancy schmancy metaprogramming to make the three fields dynamic.