### PR TITLE
SB-6453: Remove requirement for fields that are not required

### DIFF
--- a/lib/adroll/adgroup.rb
+++ b/lib/adroll/adgroup.rb
@@ -74,7 +74,7 @@ module AdRoll
         end
 
         def create(campaign:, name: nil, ads: nil, positive_segments: nil, negative_segments: nil,
-                   geo_targets:, geo_targets_countries: nil, geo_targets_regions:)
+                   geo_targets: nil, geo_targets_countries: nil, geo_targets_regions: nil)
           params = {
             campaign: campaign,
             name: name,

--- a/lib/adroll/rule.rb
+++ b/lib/adroll/rule.rb
@@ -2,7 +2,7 @@ module AdRoll
   module Api
     class Rule < AdRoll::Api::Service
       class << self
-        def create(pixel:, type:, order:, name:, display_name:, pattern:, source:)
+        def create(pixel:, type:, order:, name:, display_name: nil, pattern:, source: nil)
           params = {
             pixel: pixel,
             type: type,

--- a/lib/adroller/version.rb
+++ b/lib/adroller/version.rb
@@ -1,3 +1,3 @@
 module Adroller
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
### Problem
While working on JIRA card SB-6453 "Modify API calls not using AdRoller gem to use it instead", I learned that 4 fields that were listed as required in the gem are not required by the AdRoll Api. 

### Solution
Remove requirement for fields that are not required