### PR TITLE
SB-7217: Update instagram_account with new parameter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    adroller (1.5.0)
+    adroller (1.5.1)
       httmultiparty (~> 0.3.13)
       httparty (~> 0.13.1)
 
@@ -59,7 +59,7 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.10)
     method_source (0.8.2)
-    mimemagic (0.3.1)
+    mimemagic (0.3.2)
     minitest (5.4.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)

--- a/lib/adroll/api/facebook.rb
+++ b/lib/adroll/api/facebook.rb
@@ -3,7 +3,7 @@ require 'adroll/service'
 module AdRoll
   module Api
     class Facebook < AdRoll::Api::Service
-      WHITELIST_PARAMS = [:page_url, :account_id]
+      WHITELIST_PARAMS = [:page_url, :account_id, :advertiser_eid]
 
       def fb_page_url(params)
         call_api(:post, __method__, validate_params(params))

--- a/lib/adroller/version.rb
+++ b/lib/adroller/version.rb
@@ -1,3 +1,3 @@
 module Adroller
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end


### PR DESCRIPTION
AdRoll has updated their instagram_account endpoint to allow for the advertiser_eid, so I've updated the list of whitelisted parameters.

![screen shot 2016-08-05 at 2 47 49 pm](https://cloud.githubusercontent.com/assets/715806/17447296/a4c65fd6-5b1b-11e6-80a0-0b2445dffd5b.png)
