### PR TITLE
SB-7604: Add Support for Uhura api

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    adroller (1.5.2)
+    adroller (1.6.0)
       httmultiparty (~> 0.3.13)
       httparty (~> 0.13.1)
 

--- a/lib/adroll.rb
+++ b/lib/adroll.rb
@@ -29,54 +29,59 @@ require 'adroll/uhura/attributions'
 require 'adroll/uhura/deliveries'
 
 module AdRoll
-  module Api
-    def self.api_base_url
-      'https://api.adroll.com/v1'
-    end
+  def self.api_base_url
+    'https://api.adroll.com/v1'
+  end
 
-    def self.uhura_base_url
-      'https://app.adroll.com/uhura/v1'
-    end
+  def self.uhura_base_url
+    'https://app.adroll.com/uhura/v1'
+  end
 
-    def self.user_name
-      @user_name || ENV['ADROLL_USERNAME']
-    end
+  def self.user_name
+    @user_name || ENV['ADROLL_USERNAME']
+  end
 
-    def self.password
-      @password || ENV['ADROLL_PASSWORD']
-    end
+  def self.password
+    @password || ENV['ADROLL_PASSWORD']
+  end
 
-    def self.debug?
-      ENV['DEBUG'] == 'true'
-    end
+  def self.debug?
+    ENV['DEBUG'] == 'true'
+  end
 
-    def self.organization_eid
-      @organization_eid || ENV['ADROLL_ORGANIZATION_EID']
-    end
+  def self.organization_eid
+    @organization_eid || ENV['ADROLL_ORGANIZATION_EID']
+  end
 
-    def self.set_account_data(user_name, password, organization_eid)
-      @user_name = user_name
-      @password = password
-      @organization_eid = organization_eid
-    end
+  def self.set_account_data(user_name, password, organization_eid)
+    @user_name = user_name
+    @password = password
+    @organization_eid = organization_eid
+  end
 
-    def self.services
-      self.constants.select { |c| Class === self.const_get(c) } - [:Service]
-    end
+  def self.uhura_services
+    AdRoll::Uhura.constants.select { |c| Class === AdRoll::Uhura.const_get(c) } - [:Service]
+  end
 
-    def self.service_classes
-      services.map { |m| "#{self.name}::#{m}".constantize }
-    end
+  def self.api_services
+    AdRoll::Api.constants.select { |c| Class === AdRoll::Api.const_get(c) } - [:Service]
+  end
 
-    def self.included(base)
-      base.class_eval do
-        class << self
+  def self.uhura_service_classes
+    uhura_services.map { |m| "#{AdRoll::Uhura.name}::#{m}".constantize }
+  end
 
-          def set_account_data(user_name: , password: , organization_eid: )
-            AdRoll::Api.set_account_data(user_name, password, organization_eid)
-          end
+  def self.api_service_classes
+    api_services.map { |m| "#{AdRoll::Api.name}::#{m}".constantize }
+  end
+  def self.included(base)
+    base.class_eval do
+      class << self
 
+        def set_account_data(user_name: , password: , organization_eid: )
+          AdRoll.set_account_data(user_name, password, organization_eid)
         end
+
       end
     end
   end

--- a/lib/adroll.rb
+++ b/lib/adroll.rb
@@ -1,6 +1,11 @@
 require 'httparty'
 require 'httmultiparty'
 
+require 'adroll/client'
+require 'adroll/service'
+require 'adroll/utils'
+
+require 'adroll/api/service'
 require 'adroll/api/ad'
 require 'adroll/api/adgroup'
 require 'adroll/api/advertisable'
@@ -19,12 +24,9 @@ require 'adroll/api/rule'
 require 'adroll/api/segment'
 require 'adroll/api/user'
 
+require 'adroll/uhura/service'
 require 'adroll/uhura/attributions'
 require 'adroll/uhura/deliveries'
-
-require 'adroll/client'
-require 'adroll/service'
-require 'adroll/utils'
 
 module AdRoll
   module Api

--- a/lib/adroll.rb
+++ b/lib/adroll.rb
@@ -19,14 +19,21 @@ require 'adroll/api/rule'
 require 'adroll/api/segment'
 require 'adroll/api/user'
 
+require 'adroll/uhura/attributions'
+require 'adroll/uhura/deliveries'
+
 require 'adroll/client'
 require 'adroll/service'
 require 'adroll/utils'
 
 module AdRoll
   module Api
-    def self.base_url
+    def self.api_base_url
       'https://api.adroll.com/v1'
+    end
+
+    def self.uhura_base_url
+      'https://app.adroll.com/uhura/v1'
     end
 
     def self.user_name

--- a/lib/adroll/api/service.rb
+++ b/lib/adroll/api/service.rb
@@ -4,7 +4,7 @@ module AdRoll
   module Api
     class Service < AdRoll::Service
       def service_url
-        File.join(AdRoll::Api.api_base_url, self.class.name.demodulize.underscore)
+        File.join(AdRoll.api_base_url, self.class.name.demodulize.underscore)
       end
     end
   end

--- a/lib/adroll/api/service.rb
+++ b/lib/adroll/api/service.rb
@@ -1,0 +1,9 @@
+module AdRoll
+  module Api
+    class Service < AdRoll::Service
+      def service_url
+        File.join(AdRoll::Api.api_base_url, self.class.name.demodulize.underscore)
+      end
+    end
+  end
+end

--- a/lib/adroll/api/service.rb
+++ b/lib/adroll/api/service.rb
@@ -1,3 +1,5 @@
+require 'adroll/service'
+
 module AdRoll
   module Api
     class Service < AdRoll::Service

--- a/lib/adroll/client.rb
+++ b/lib/adroll/client.rb
@@ -2,15 +2,21 @@ module AdRoll
   class Client
     attr_accessor :user_name, :password, :organization_eid, :debug
 
-    def initialize(user_name:, password:, organization_eid:, debug: false)
+    def initialize(user_name:, password:, organization_eid:, data_source: 'api', debug: false)
       @user_name = user_name
       @password = password
       @organization_eid = organization_eid
       @debug = debug
+      @data_source = data_source
     end
 
     def method_missing(meth, *args, &block)
+      case @data_source
+      when 'api'
       "AdRoll::Api::#{camelize(meth)}".constantize.new(client: self)
+      when 'uhura'
+      "AdRoll::Uhura::#{camelize(meth)}".constantize.new(client: self)
+      end
     end
 
     def debug?

--- a/lib/adroll/service.rb
+++ b/lib/adroll/service.rb
@@ -1,71 +1,69 @@
 module AdRoll
-  module Api
-    class Service
-      attr_accessor :client
+  class Service
+    attr_accessor :client
 
-      # Override Object's clone method and pass to method_missing
-      def self.clone(params)
-        method_missing(:clone, params)
-      end
+    # Override Object's clone method and pass to method_missing
+    def self.clone(params)
+      method_missing(:clone, params)
+    end
 
-      def self.method_missing(meth, *args, &block)
-        # @TODO add logging functionality and put deprecation warnings here
-        klass = self.new
-        klass.send(meth, *args)
-      end
+    def self.method_missing(meth, *args, &block)
+      # @TODO add logging functionality and put deprecation warnings here
+      klass = self.new
+      klass.send(meth, *args)
+    end
 
-      def initialize(options = {})
-        @client = options.delete(:client)
-      end
+    def initialize(options = {})
+      @client = options.delete(:client)
+    end
 
-      def service_method
-        AdRoll::Utils.snakecase(self.class.to_s.gsub(/^.*::/, ''))
-      end
+    def service_method
+      AdRoll::Utils.snakecase(self.class.to_s.gsub(/^.*::/, ''))
+    end
 
-      private
+    private
 
-      def service_url
-        File.join(AdRoll::Api.base_url, self.class.name.demodulize.underscore)
-      end
+    def service_url
+      raise NotImplementedError
+    end
 
-      def basic_auth
-        { username: username, password: password }
-      end
+    def basic_auth
+      { username: username, password: password }
+    end
 
-      def username
-        (client && client.user_name) || AdRoll::Api.user_name
-      end
+    def username
+      (client && client.user_name) || AdRoll::Api.user_name
+    end
 
-      def password
-        (client && client.password) || AdRoll::Api.password
-      end
+    def password
+      (client && client.password) || AdRoll::Api.password
+    end
 
-      def debug_output
-        $stdout if (client && client.debug?) || AdRoll::Api.debug?
-      end
+    def debug_output
+      $stdout if (client && client.debug?) || AdRoll::Api.debug?
+    end
 
-      def call_api(request_method, endpoint, query_params)
-        request_uri = File.join(service_url, endpoint.to_s)
+    def call_api(request_method, endpoint, query_params)
+      request_uri = File.join(service_url, endpoint.to_s)
 
-        if request_method == :get
-          response = HTTParty.send(request_method, request_uri,
-                                   basic_auth: basic_auth, query: query_params, debug_output: debug_output)
+      if request_method == :get
+        response = HTTParty.send(request_method, request_uri,
+                                 basic_auth: basic_auth, query: query_params, debug_output: debug_output)
+      else
+        if request_uri == 'https://api.adroll.com/v1/ad/create'
+          response = HTTMultiParty.send(request_method, request_uri,
+                                        basic_auth: basic_auth, body: query_params, debug_output: debug_output)
+
         else
-          if request_uri == 'https://api.adroll.com/v1/ad/create'
-            response = HTTMultiParty.send(request_method, request_uri,
-                                          basic_auth: basic_auth, body: query_params, debug_output: debug_output)
-
-          else
-            response = HTTParty.send(request_method, request_uri,
-                                     basic_auth: basic_auth, body: query_params, debug_output: debug_output)
-          end
+          response = HTTParty.send(request_method, request_uri,
+                                   basic_auth: basic_auth, body: query_params, debug_output: debug_output)
         end
+      end
 
-        begin
-          JSON.parse(response.body)
-        rescue JSON::ParserError
-          { error: 'JSON::ParserError', response: response.body }
-        end
+      begin
+        JSON.parse(response.body)
+      rescue JSON::ParserError
+        { error: 'JSON::ParserError', response: response.body }
       end
     end
   end

--- a/lib/adroll/service.rb
+++ b/lib/adroll/service.rb
@@ -32,15 +32,15 @@ module AdRoll
     end
 
     def username
-      (client && client.user_name) || AdRoll::Api.user_name
+      (client && client.user_name) || AdRoll.user_name
     end
 
     def password
-      (client && client.password) || AdRoll::Api.password
+      (client && client.password) || AdRoll.password
     end
 
     def debug_output
-      $stdout if (client && client.debug?) || AdRoll::Api.debug?
+      $stdout if (client && client.debug?) || AdRoll.debug?
     end
 
     def call_api(request_method, endpoint, query_params)

--- a/lib/adroll/uhura/attributions.rb
+++ b/lib/adroll/uhura/attributions.rb
@@ -1,4 +1,4 @@
-require 'adroll/service'
+require 'adroll/uhura/service'
 
 module AdRoll
   module Uhura

--- a/lib/adroll/uhura/attributions.rb
+++ b/lib/adroll/uhura/attributions.rb
@@ -1,0 +1,36 @@
+require 'adroll/service'
+
+module AdRoll
+  module Uhura
+    class Attributions < AdRoll::Uhura::Service
+      WHITELIST_PARAMS = [:breakdowns, :advertisable_eid, :segment_eids, :adgroup_eids,
+                          :ad_eids, :start_date, :end_date, :past_days, :currency]
+
+      def ad(params)
+        call_api(:get, __method__, validate_params(params))
+      end
+
+      def adgroup(params)
+        call_api(:get, __method__, validate_params(params))
+      end
+
+      def advertisable(params)
+        call_api(:get, __method__, validate_params(params))
+      end
+
+      def export(params)
+        call_api(:get, __method__, validate_params(params))
+      end
+
+      def segment(params)
+        call_api(:get, __method__, validate_params(params))
+      end
+
+      private
+
+      def validate_params(params)
+        params.reject { |key, value| !WHITELIST_PARAMS.include?(key) || value.nil? }
+      end
+    end
+  end
+end

--- a/lib/adroll/uhura/deliveries.rb
+++ b/lib/adroll/uhura/deliveries.rb
@@ -1,4 +1,4 @@
-require 'adroll/service'
+require 'adroll/uhura/service'
 
 module AdRoll
   module Uhura

--- a/lib/adroll/uhura/deliveries.rb
+++ b/lib/adroll/uhura/deliveries.rb
@@ -1,0 +1,36 @@
+require 'adroll/service'
+
+module AdRoll
+  module Uhura
+    class Deliveries < AdRoll::Uhura::Service
+      WHITELIST_PARAMS = [:breakdowns, :advertisable_eid, :segment_eids, :adgroup_eids,
+                          :ad_eids, :start_date, :end_date, :past_days, :currency]
+
+      def ad(params)
+        call_api(:get, __method__, validate_params(params))
+      end
+
+      def adgroup(params)
+        call_api(:get, __method__, validate_params(params))
+      end
+
+      def advertisable(params)
+        call_api(:get, __method__, validate_params(params))
+      end
+
+      def export(params)
+        call_api(:get, __method__, validate_params(params))
+      end
+
+      def domain(params)
+        call_api(:get, __method__, validate_params(params))
+      end
+
+      private
+
+      def validate_params(params)
+        params.reject { |key, value| !WHITELIST_PARAMS.include?(key) || value.nil? }
+      end
+    end
+  end
+end

--- a/lib/adroll/uhura/service.rb
+++ b/lib/adroll/uhura/service.rb
@@ -4,7 +4,7 @@ module AdRoll
   module Uhura
     class Service < AdRoll::Service
       def service_url
-        File.join(AdRoll::Api.uhura_base_url, self.class.name.demodulize.underscore)
+        File.join(AdRoll.uhura_base_url, self.class.name.demodulize.underscore)
       end
 
       def call_api(request_method, endpoint, query_params)

--- a/lib/adroll/uhura/service.rb
+++ b/lib/adroll/uhura/service.rb
@@ -1,0 +1,28 @@
+module AdRoll
+  module Uhura
+    class Service < AdRoll::Service
+      def service_url
+        File.join(AdRoll::Api.uhura_base_url, self.class.name.demodulize.underscore)
+      end
+
+      def call_api(request_method, endpoint, query_params)
+        request_uri = File.join(service_url, endpoint.to_s)
+
+        if request_method == :get
+          response = HTTParty.send(request_method, request_uri,
+                                   basic_auth: basic_auth, query: query_params, debug_output: debug_output)
+        else
+          response = HTTParty.send(request_method, request_uri,
+                                   basic_auth: basic_auth, body: query_params, debug_output: debug_output)
+        end
+
+        begin
+          JSON.parse(response.body)
+        rescue JSON::ParserError
+          { error: 'JSON::ParserError', response: response.body }
+        end
+      end
+
+    end
+  end
+end

--- a/lib/adroll/uhura/service.rb
+++ b/lib/adroll/uhura/service.rb
@@ -1,3 +1,5 @@
+require 'adroll/service'
+
 module AdRoll
   module Uhura
     class Service < AdRoll::Service

--- a/lib/adroller/version.rb
+++ b/lib/adroller/version.rb
@@ -1,3 +1,3 @@
 module Adroller
-  VERSION = '1.5.3'
+  VERSION = '1.6.0'
 end

--- a/spec/lib/adroll/api/ad_spec.rb
+++ b/spec/lib/adroll/api/ad_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::Ad do
-  let!(:basic_auth) { "#{AdRoll::Api.user_name}:#{AdRoll::Api.password}" }
+  let!(:basic_auth) { "#{AdRoll.user_name}:#{AdRoll.password}" }
   let!(:base_uri) { "https://api.adroll.com/v1/ad" }
 
   subject { described_class }

--- a/spec/lib/adroll/client_spec.rb
+++ b/spec/lib/adroll/client_spec.rb
@@ -2,56 +2,113 @@ require 'spec_helper'
 
 describe AdRoll::Client do
   describe 'all routes' do
-    client = AdRoll::Client.new user_name: 'USERNAME', password: 'PASSWORD', organization_eid: 'ORG123XYZ'
+    context 'when data_source is not specified or is api' do
+      client = AdRoll::Client.new user_name: 'USERNAME', password: 'PASSWORD', organization_eid: 'ORG123XYZ'
 
-    # classes = [AdRoll::Api::MobileApp]
-    classes = AdRoll::Api.service_classes
-    classes.each do |service|
-      service_method = service.service_method
-      service.instance_methods(false).each do |method|
-        ar = []
-        hsh = {}
+      # classes = [AdRoll::Api::MobileApp]
+      classes = AdRoll.api_service_classes
+      classes.each do |service|
+        service_method = service.service_method
+        service.instance_methods(false).each do |method|
+          ar = []
+          hsh = {}
 
-        service.instance_method(method).parameters.map do |param|
-          case param[0]
-          when :req
-            ar << {}
-          when :keyreq
-            hsh[param[1]] = rand(1..10)
+          service.instance_method(method).parameters.map do |param|
+            case param[0]
+            when :req
+              ar << {}
+            when :keyreq
+              hsh[param[1]] = rand(1..10)
+            end
           end
-        end
 
 
-        it "#{service.name}##{service_method} is expected to call #{method}" do
-          if ar.empty?
-            client.send(service_method).send(method, hsh)
-          else
-            client.send(service_method).send(method, *ar)
+          it "#{service.name}##{service_method} is expected to call #{method}" do
+            if ar.empty?
+              client.send(service_method).send(method, hsh)
+            else
+              client.send(service_method).send(method, *ar)
+            end
+            expect(WebMock).to have_requested(:any, /.*\/#{service_method}/)
           end
-          expect(WebMock).to have_requested(:any, /.*\/#{service_method}/)
         end
       end
     end
-  end
 
-  context 'when a service is called' do
-    let(:ad_spy) { double(:ad, create: true) }
-    let(:params) do
-      {
-        user_name: 'foo',
-        password: 'bar',
-        organization_eid: 'spam'
-      }
+    context 'when a service is called' do
+      let(:ad_spy) { double(:ad, create: true) }
+      let(:params) do
+        {
+          user_name: 'foo',
+          password: 'bar',
+          organization_eid: 'spam'
+        }
+      end
+      before do
+        allow(AdRoll::Api::Ad).to receive(:new) { ad_spy }
+      end
+
+      subject(:client) { described_class.new params }
+
+      it 'should create a new instance of that service' do
+        client.ad.create 'foo'
+        expect(ad_spy).to have_received(:create).with 'foo'
+      end
     end
-    before do
-      allow(AdRoll::Api::Ad).to receive(:new) { ad_spy }
+
+    context 'when data_source is uhura' do
+      client = AdRoll::Client.new data_source: 'uhura',user_name: 'USERNAME', password: 'PASSWORD', organization_eid: 'ORG123XYZ'
+
+      # classes = [AdRoll::Uhura::Attributions]
+      classes = AdRoll.uhura_service_classes
+      classes.each do |service|
+        service_method = service.service_method
+        service.instance_methods(false).each do |method|
+          ar = []
+          hsh = {}
+
+          service.instance_method(method).parameters.map do |param|
+            case param[0]
+            when :req
+              ar << {}
+            when :keyreq
+              hsh[param[1]] = rand(1..10)
+            end
+          end
+
+
+          it "#{service.name}##{service_method} is expected to call #{method}" do
+            if ar.empty?
+              client.send(service_method).send(method, hsh)
+            else
+              client.send(service_method).send(method, *ar)
+            end
+            expect(WebMock).to have_requested(:any, /.*\/#{service_method}/)
+          end
+        end
+      end
     end
 
-    subject(:client) { described_class.new params }
+    context 'when a service is called' do
+      let(:ad_spy) { double(:attributions, ad: true) }
+      let(:params) do
+        {
+          'data_source': 'uhura',
+          user_name: 'foo',
+          password: 'bar',
+          organization_eid: 'spam'
+        }
+      end
+      before do
+        allow(AdRoll::Uhura::Attributions).to receive(:new) { ad_spy }
+      end
 
-    it 'should create a new instance of that service' do
-      client.ad.create 'foo'
-      expect(ad_spy).to have_received(:create).with 'foo'
+      subject(:client) { described_class.new params }
+
+      it 'should create a new instance of that service' do
+        client.attributions.ad 'foo'
+        expect(ad_spy).to have_received(:ad).with 'foo'
+      end
     end
   end
 end

--- a/spec/lib/adroll/uhura/attributions_spec.rb
+++ b/spec/lib/adroll/uhura/attributions_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe AdRoll::Uhura::Attributions do
+  let!(:basic_auth) { "#{AdRoll.user_name}:#{AdRoll.password}" }
+  let!(:base_uri) { "https://app.adroll.com/uhura/v1/attributions" }
+
+  subject { described_class }
+
+
+  describe '::ad' do
+    let!(:request_uri) { "#{base_uri}/ad" }
+    let!(:params) do
+      { ad_eids: 'AD123' }
+    end
+
+    it 'calls the api with the correct params' do
+      subject.ad(ad_eids: 'AD123')
+      expect(WebMock).to have_requested(:get, request_uri).with(query: params)
+    end
+  end
+
+  describe '::adgroup' do
+    let!(:request_uri) { "#{base_uri}/adgroup" }
+    let!(:params) do
+      { ad_eids: 'AD123' }
+    end
+
+    it 'calls the api with the correct params' do
+      subject.adgroup(ad_eids: 'AD123')
+      expect(WebMock).to have_requested(:get, request_uri).with(query: params)
+    end
+  end
+
+  describe '::advertisable' do
+    let!(:request_uri) { "#{base_uri}/advertisable" }
+    let!(:params) do
+      { ad_eids: 'AD123' }
+    end
+
+    it 'calls the api with the correct params' do
+      subject.advertisable(ad_eids: 'AD123')
+      expect(WebMock).to have_requested(:get, request_uri).with(query: params)
+    end
+  end
+
+  describe '::export' do
+    let!(:request_uri) { "#{base_uri}/export" }
+    let!(:params) do
+      { ad_eids: 'AD123' }
+    end
+
+    it 'calls the api with the correct params' do
+      subject.export(ad_eids: 'AD123')
+      expect(WebMock).to have_requested(:get, request_uri).with(query: params)
+    end
+  end
+
+  describe '::segment' do
+    let!(:request_uri) { "#{base_uri}/segment" }
+    let!(:params) do
+      { ad_eids: 'AD123' }
+    end
+
+    it 'calls the api with the correct params' do
+      subject.segment(ad_eids: 'AD123')
+      expect(WebMock).to have_requested(:get, request_uri).with(query: params)
+    end
+  end
+end

--- a/spec/lib/adroll/uhura/deliveries_spec.rb
+++ b/spec/lib/adroll/uhura/deliveries_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe AdRoll::Uhura::Deliveries do
+  let!(:basic_auth) { "#{AdRoll.user_name}:#{AdRoll.password}" }
+  let!(:base_uri) { "https://app.adroll.com/uhura/v1/deliveries" }
+
+  subject { described_class }
+
+
+  describe '::ad' do
+    let!(:request_uri) { "#{base_uri}/ad" }
+    let!(:params) do
+      { ad_eids: 'AD123' }
+    end
+
+    it 'calls the api with the correct params' do
+      subject.ad(ad_eids: 'AD123')
+      expect(WebMock).to have_requested(:get, request_uri).with(query: params)
+    end
+  end
+
+  describe '::adgroup' do
+    let!(:request_uri) { "#{base_uri}/adgroup" }
+    let!(:params) do
+      { ad_eids: 'AD123' }
+    end
+
+    it 'calls the api with the correct params' do
+      subject.adgroup(ad_eids: 'AD123')
+      expect(WebMock).to have_requested(:get, request_uri).with(query: params)
+    end
+  end
+
+  describe '::advertisable' do
+    let!(:request_uri) { "#{base_uri}/advertisable" }
+    let!(:params) do
+      { ad_eids: 'AD123' }
+    end
+
+    it 'calls the api with the correct params' do
+      subject.advertisable(ad_eids: 'AD123')
+      expect(WebMock).to have_requested(:get, request_uri).with(query: params)
+    end
+  end
+
+  describe '::export' do
+    let!(:request_uri) { "#{base_uri}/export" }
+    let!(:params) do
+      { ad_eids: 'AD123' }
+    end
+
+    it 'calls the api with the correct params' do
+      subject.export(ad_eids: 'AD123')
+      expect(WebMock).to have_requested(:get, request_uri).with(query: params)
+    end
+  end
+
+  describe '::domain' do
+    let!(:request_uri) { "#{base_uri}/domain" }
+    let!(:params) do
+      { ad_eids: 'AD123' }
+    end
+
+    it 'calls the api with the correct params' do
+      subject.domain(ad_eids: 'AD123')
+      expect(WebMock).to have_requested(:get, request_uri).with(query: params)
+    end
+  end
+end

--- a/spec/lib/adroll_spec.rb
+++ b/spec/lib/adroll_spec.rb
@@ -1,35 +1,47 @@
 require 'spec_helper'
 
-describe AdRoll::Api do
-  describe '.service_classes' do
-    subject(:service_classes) { described_class.service_classes }
+describe AdRoll do
+  describe '.api_service_classes' do
+    subject(:api_service_classes) { described_class.api_service_classes }
 
     it { is_expected.to include AdRoll::Api::Ad }
   end
 
-  describe '.services' do
-    subject(:services) { described_class.services }
+  describe '.api_services' do
+    subject(:api_services) { described_class.api_services }
 
     it { is_expected.to include :Ad }
   end
 
+  describe '.uhura_service_classes' do
+    subject(:uhura_service_classes) { described_class.uhura_service_classes }
+
+    it { is_expected.to include AdRoll::Uhura::Attributions }
+  end
+
+  describe '.uhura_services' do
+    subject(:uhura_services) { described_class.uhura_services }
+
+    it { is_expected.to include :Deliveries }
+  end
+
   context 'when using enviroment variables' do
     it 'sets user_name' do
-      expect(AdRoll::Api.user_name).to eq('USERNAME')
+      expect(AdRoll.user_name).to eq('USERNAME')
     end
 
     it 'sets password' do
-      expect(AdRoll::Api.password).to eq('PASSWORD')
+      expect(AdRoll.password).to eq('PASSWORD')
     end
 
     it 'sets organization_eid' do
-      expect(AdRoll::Api.organization_eid).to eq('ORG123XYZ')
+      expect(AdRoll.organization_eid).to eq('ORG123XYZ')
     end
   end
 
   context 'when using include' do
     class Dummy
-      include AdRoll::Api
+      include AdRoll
     end
 
     subject { Dummy }
@@ -39,15 +51,15 @@ describe AdRoll::Api do
     end
 
     it 'sets user_name' do
-      expect(AdRoll::Api.user_name).to eq('username')
+      expect(AdRoll.user_name).to eq('username')
     end
 
     it 'sets password' do
-      expect(AdRoll::Api.password).to eq('abc')
+      expect(AdRoll.password).to eq('abc')
     end
 
     it 'sets organization_eid' do
-      expect(AdRoll::Api.organization_eid).to eq('abc123')
+      expect(AdRoll.organization_eid).to eq('abc123')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,10 @@ RSpec.configure do |config|
       .with(basic_auth: ['USERNAME', 'PASSWORD'])
       .to_return(status: [200, 'OK'], body: { results: {} }.to_json)
 
-    AdRoll::Api.set_account_data('USERNAME', 'PASSWORD', 'ORG123XYZ')
+    stub_request(:any, /https:\/\/app.adroll.com\/.*/)
+      .with(basic_auth: ['USERNAME', 'PASSWORD'])
+      .to_return(status: [200, 'OK'], body: { results: {} }.to_json)
+    AdRoll.set_account_data('USERNAME', 'PASSWORD', 'ORG123XYZ')
   end
 end
 


### PR DESCRIPTION
- Add AdRoll::Uhura module with its own Service superclass
- Give AdRoll::Api its own Service superclass too
- Add Attributions and Deliveries services to AdRoll::Uhura
- Allow data_source to be specified when creating a new AdRoll::Client , default is `api`

` @uhura_client = AdRoll::Client.new(
      user_name: @organization.username,
        password: @organization.password,
        organization_eid: @organization.organization_eid,
        data_source: 'uhura')`