### PR TITLE
Fix missing dependency issue

### DIFF
--- a/adroller.gemspec
+++ b/adroller.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'httparty', '~> 0.13.1'
   spec.add_dependency 'httmultiparty', '~> 0.3.13'
+  spec.add_dependency 'activesupport', '>= 3.2'
 end

--- a/lib/adroll.rb
+++ b/lib/adroll.rb
@@ -1,5 +1,6 @@
 require 'httparty'
 require 'httmultiparty'
+require 'active_support/core_ext/string'
 
 require 'adroll/client'
 require 'adroll/service'


### PR DESCRIPTION
`String#Demodulize` is not a standard method, but is typically available to developers using `rails`. Added this dependency for users of the gem whose environments don't require `rails` or `active_support` by default. `String#Demodulize` is added via `active_support/core_ext/string`.

Areas of reference: 
- https://github.com/springbot/adroller/blob/master/lib/adroll/api/service.rb
- https://github.com/springbot/adroller/blob/master/lib/adroll/uhura/service.rb
