### PR TITLE
SB-10165: Add additional method and param to RollcrawlConfiguration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    adroller (2.0.1)
+    adroller (2.0.2)
       activesupport (>= 3.2)
       httmultiparty (~> 0.3.13)
       httparty (~> 0.13.1)

--- a/lib/adroll/api/rollcrawl_configuration.rb
+++ b/lib/adroll/api/rollcrawl_configuration.rb
@@ -3,8 +3,26 @@ module AdRoll
     class RollcrawlConfiguration < AdRoll::Api::Service
       WHITELIST_PARAMS = [:advertisable,
                           :product_id_from_page_scheme,
+                          :product_id_from_page_attribute,
                           :product_id_from_page_regular_expression,
-                          :product_id_from_page_attribute].freeze
+                          :product_id_from_page_path,
+                          :product_id_from_page_regular_expression_replace,
+                          :product_group_from_page_scheme,
+                          :product_group_from_page_attribute,
+                          :product_group_from_page_regular_expression,
+                          :product_group_from_page_path,
+                          :product_group_from_page_regular_expression_replace,
+                          :feed_url,
+                          :feedtype,
+                          :skipfirstrow,
+                          :delimiter,
+                          :escapechar,
+                          :quotechar,
+                          :skipinitialspace,
+                          :encoding,
+                          :tag_name,
+                          :locale,
+                          :prices_in_locale_format].freeze
 
       def edit(params)
         call_api(:put, __method__, sanitize_params(params))
@@ -12,6 +30,10 @@ module AdRoll
 
       def get(params)
         call_api(:get, __method__, sanitize_params(params))
+      end
+
+      def add_feed_config(params)
+        call_api(:post, __method__, sanitize_params(params))
       end
 
       private

--- a/lib/adroller/version.rb
+++ b/lib/adroller/version.rb
@@ -1,3 +1,3 @@
 module Adroller
-  VERSION = '2.0.1'.freeze
+  VERSION = '2.0.2'.freeze
 end

--- a/spec/lib/adroll/api/rollcrawl_configuration_spec.rb
+++ b/spec/lib/adroll/api/rollcrawl_configuration_spec.rb
@@ -34,4 +34,24 @@ describe AdRoll::Api::RollcrawlConfiguration do
         .with(query: params)
     end
   end
+
+  describe '::add_feed_config' do
+    let(:request_uri) { "#{base_uri}/add_feed_config" }
+    let(:params) do
+      {
+        advertisable: 'abc123',
+        feed_url: 'http://url.com'
+      }
+    end
+
+    before do
+      params[:feed_url] = CGI.escape(params[:feed_url])
+    end
+
+    it 'call the api with the correct params' do
+      subject.add_feed_config(params)
+      expect(WebMock).to have_requested(:post, request_uri)
+        .with(body: params)
+    end
+  end
 end


### PR DESCRIPTION
Per the documentation, additional methods and params have been added to the RollcrawlConfiguration model.

https://developers.adroll.com/guides/product-feed-setup.html#post--api-v1-advertisable-enable_rollcrawl