### PR TITLE
Add apikey to request uri NOT request body

### DIFF
--- a/lib/adroll/service.rb
+++ b/lib/adroll/service.rb
@@ -53,7 +53,7 @@ module AdRoll
 
     def make_api_call(request_method, request_uri, query_params)
       # Include api_key with every call.
-      query_params['apikey'] = AdRoll.api_key
+      request_uri << "?apikey=#{AdRoll.api_key}"
 
       if request_method == :get
         perform_get(request_method, request_uri, query_params)

--- a/lib/adroller/version.rb
+++ b/lib/adroller/version.rb
@@ -1,3 +1,3 @@
 module Adroller
-  VERSION = '2.0.2'.freeze
+  VERSION = '3.0.1'.freeze
 end

--- a/spec/lib/adroll/api/ad_spec.rb
+++ b/spec/lib/adroll/api/ad_spec.rb
@@ -6,6 +6,10 @@ describe AdRoll::Api::Ad do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::clone' do
     let!(:request_uri) { "#{base_uri}/clone" }
 

--- a/spec/lib/adroll/api/adgroup_spec.rb
+++ b/spec/lib/adroll/api/adgroup_spec.rb
@@ -6,6 +6,10 @@ describe AdRoll::Api::Adgroup do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::add_demographic_target' do
     let(:request_uri) { "#{base_uri}/add_demographic_target" }
     let(:params) do
@@ -144,7 +148,7 @@ describe AdRoll::Api::Adgroup do
     it 'calls the api with the correct params' do
       subject.create(params)
       expect(WebMock).to have_requested(:post, request_uri)
-        # .with(body: params) <= rspec won't play nice but this is an emergency to get it out
+      # .with(body: params) <= rspec won't play nice but this is an emergency to get it out
     end
   end
 

--- a/spec/lib/adroll/api/advertisable_spec.rb
+++ b/spec/lib/adroll/api/advertisable_spec.rb
@@ -5,6 +5,10 @@ describe AdRoll::Api::Advertisable do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::create' do
     let!(:request_uri) { "#{base_uri}/create" }
 

--- a/spec/lib/adroll/api/campaign_spec.rb
+++ b/spec/lib/adroll/api/campaign_spec.rb
@@ -5,6 +5,10 @@ describe AdRoll::Api::Campaign do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::create' do
     let(:request_uri) { "#{base_uri}/create" }
     let(:params) do

--- a/spec/lib/adroll/api/facebook_spec.rb
+++ b/spec/lib/adroll/api/facebook_spec.rb
@@ -5,6 +5,10 @@ describe AdRoll::Api::Facebook do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::fb_page_url' do
     let(:request_uri) { "#{base_uri}/fb_page_url" }
     let(:params) do

--- a/spec/lib/adroll/api/invoice_spec.rb
+++ b/spec/lib/adroll/api/invoice_spec.rb
@@ -5,6 +5,10 @@ describe AdRoll::Api::Invoice do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::get' do
     let(:request_uri) { "#{base_uri}/get" }
     let(:params) do

--- a/spec/lib/adroll/api/organization_spec.rb
+++ b/spec/lib/adroll/api/organization_spec.rb
@@ -5,6 +5,10 @@ describe AdRoll::Api::Organization do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::get' do
     let!(:request_uri) { "#{base_uri}/get" }
 

--- a/spec/lib/adroll/api/pixel_spec.rb
+++ b/spec/lib/adroll/api/pixel_spec.rb
@@ -5,6 +5,10 @@ describe AdRoll::Api::Pixel do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::get' do
     let(:request_uri) { "#{base_uri}/get" }
     let(:params) do

--- a/spec/lib/adroll/api/report_spec.rb
+++ b/spec/lib/adroll/api/report_spec.rb
@@ -5,6 +5,10 @@ describe AdRoll::Api::Report do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::ad' do
     let(:request_uri) { "#{base_uri}/ad" }
     let(:params) do

--- a/spec/lib/adroll/api/rollcrawl_configuration_spec.rb
+++ b/spec/lib/adroll/api/rollcrawl_configuration_spec.rb
@@ -5,6 +5,10 @@ describe AdRoll::Api::RollcrawlConfiguration do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::edit' do
     let(:request_uri) { "#{base_uri}/edit" }
     let(:params) do

--- a/spec/lib/adroll/api/rule_spec.rb
+++ b/spec/lib/adroll/api/rule_spec.rb
@@ -5,6 +5,10 @@ describe AdRoll::Api::Rule do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::create' do
     let(:request_uri) { "#{base_uri}/create" }
     let(:params) do

--- a/spec/lib/adroll/api/segment_spec.rb
+++ b/spec/lib/adroll/api/segment_spec.rb
@@ -5,6 +5,10 @@ describe AdRoll::Api::Segment do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::edit' do
     let(:request_uri) { "#{base_uri}/edit" }
     let(:params) do

--- a/spec/lib/adroll/api/user_spec.rb
+++ b/spec/lib/adroll/api/user_spec.rb
@@ -5,6 +5,10 @@ describe AdRoll::Api::User do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::deactivate' do
     let(:request_uri) { "#{base_uri}/deactivate" }
     let(:params) do

--- a/spec/lib/adroll/uhura/attributions_spec.rb
+++ b/spec/lib/adroll/uhura/attributions_spec.rb
@@ -6,6 +6,10 @@ describe AdRoll::Uhura::Attributions do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::ad' do
     let!(:request_uri) { "#{base_uri}/ad" }
     let!(:params) do

--- a/spec/lib/adroll/uhura/deliveries/domain_spec.rb
+++ b/spec/lib/adroll/uhura/deliveries/domain_spec.rb
@@ -6,6 +6,10 @@ describe AdRoll::Uhura::Deliveries::Domain do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::ad' do
     let!(:request_uri) { "#{base_uri}/ad" }
     let!(:params) do

--- a/spec/lib/adroll/uhura/deliveries_spec.rb
+++ b/spec/lib/adroll/uhura/deliveries_spec.rb
@@ -6,6 +6,10 @@ describe AdRoll::Uhura::Deliveries do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::ad' do
     let!(:request_uri) { "#{base_uri}/ad" }
     let!(:params) do

--- a/spec/lib/adroll/uhura/segment_deliveries_spec.rb
+++ b/spec/lib/adroll/uhura/segment_deliveries_spec.rb
@@ -6,6 +6,10 @@ describe AdRoll::Uhura::SegmentDeliveries do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::advertisable' do
     let!(:request_uri) { "#{base_uri}/advertisable" }
     let!(:params) do

--- a/spec/lib/adroll/uhura/userlists_spec.rb
+++ b/spec/lib/adroll/uhura/userlists_spec.rb
@@ -6,6 +6,10 @@ describe AdRoll::Uhura::Userlists do
 
   subject { described_class }
 
+  before(:each) do
+    request_uri << "?apikey=#{AdRoll.api_key}"
+  end
+
   describe '::ad' do
     let!(:request_uri) { "#{base_uri}/ad" }
     let!(:params) do


### PR DESCRIPTION
AdRoll requires that `apikey` be present on the request uri and not in the request body