### PR TITLE
SB-13288: update facebook authentication call

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    adroller (3.1.0)
+    adroller (3.3.0)
       activesupport (>= 3.2)
       httmultiparty (~> 0.3.13)
       httparty (~> 0.13.1)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ A method call will return a JSON response directly from the api
 AdRoll::Api::{Endpoint Name}.{Endpoint Method}({Endpoint Parameters})
 ```
 
+When authenticating Facebook, there is an optional parameter you can pass in for the HTTP request method
+``` ruby
+AdRoll::Api::Facebook.fb_page_url(params, method = :get)
+```
+The default method is get method, and it expects the request method as symbol name e.g. :post, :get.
+Pass in :post when authenticating for first time, and :get once the Facebook page is authenticated
+
 Example
 =========
 

--- a/lib/adroll/api/facebook.rb
+++ b/lib/adroll/api/facebook.rb
@@ -5,8 +5,8 @@ module AdRoll
     class Facebook < AdRoll::Api::Service
       WHITELIST_PARAMS = [:page_url, :account_id, :advertiser_eid].freeze
 
-      def fb_page_url(params)
-        call_api(:post, __method__, sanitize_params(params))
+      def fb_page_url(params, method = :get)
+        call_api(method, __method__, sanitize_params(params))
       end
 
       def instagram_account(params)

--- a/lib/adroller/version.rb
+++ b/lib/adroller/version.rb
@@ -1,3 +1,3 @@
 module Adroller
-  VERSION = '3.2.0'.freeze
+  VERSION = '3.3.0'.freeze
 end

--- a/spec/lib/adroll/api/facebook_spec.rb
+++ b/spec/lib/adroll/api/facebook_spec.rb
@@ -18,10 +18,20 @@ describe AdRoll::Api::Facebook do
       }
     end
 
-    it 'calls the api with the correct params' do
-      subject.fb_page_url(params)
-      expect(WebMock).to have_requested(:post, request_uri)
-        .with(body: params)
+    context 'when it is a POST request' do
+      it 'calls the api with the correct params' do
+        subject.fb_page_url(params, :post)
+        expect(WebMock).to have_requested(:post, request_uri)
+          .with(body: params)
+      end
+    end
+
+    context 'when it is a GET request' do
+      it 'calls the api with the correct params' do
+        subject.fb_page_url(params, :get)
+        expect(WebMock).to have_requested(:get, request_uri)
+          .with(query: params)
+      end
     end
   end
 


### PR DESCRIPTION
### Ticket
https://springbot.atlassian.net/browse/SB-13288

### Solution
AdRoll expects a get request on the fb_page_url endpoint once the user is already authenticated. So add option to call the api on that end point with get method.