### PR TITLE
SB2-3783: Allows nil end_date for adgroups

### DIFF
--- a/lib/adroll/api/universal_campaigns.rb
+++ b/lib/adroll/api/universal_campaigns.rb
@@ -59,9 +59,10 @@ module AdRoll
         'https://services.adroll.com/activate/api/v2'
       end
 
+      # end_date is allowed to be nil for adgroups, that is why this exception is here.
       def sanitize_params(params, whitelist_constant)
         params.reject do |key, value|
-          !whitelist_constant.include?(key) || value.nil?
+          !whitelist_constant.include?(key) || (key == 'end_date' ? true : value.nil?)
         end
       end
     end


### PR DESCRIPTION
Ticket: 
https://springbot.atlassian.net/browse/SB2-3783

Notes: 
We need to allow a nil value for end_date so that an adgroup can run continuously.