### PR TITLE
SB2-4977: Changes end_date nil check to use symbol

### DIFF
--- a/lib/adroll/api/universal_campaigns.rb
+++ b/lib/adroll/api/universal_campaigns.rb
@@ -62,7 +62,7 @@ module AdRoll
       # end_date is allowed to be nil for adgroups, that is why this exception is here.
       def sanitize_params(params, whitelist_constant)
         params.reject do |key, value|
-          !whitelist_constant.include?(key) || (key == 'end_date' ? true : value.nil?)
+          !whitelist_constant.include?(key) || (key == :end_date ? true : value.nil?)
         end
       end
     end

--- a/lib/adroller/version.rb
+++ b/lib/adroller/version.rb
@@ -1,3 +1,3 @@
 module Adroller
-  VERSION = '3.7.3'.freeze
+  VERSION = '3.7.4'.freeze
 end


### PR DESCRIPTION
This PR changes the end_date nil check to use :end_date instead of 'end_date'. This has caused issues with sending nil values for end_date.